### PR TITLE
chore: 🔨  remove `tabSize` from VS Code settings file

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "files.autoSave": "onFocusChange",
-  "editor.tabSize": 2,
+  "editor.tabSize": 4,
   "editor.wordWrap": "off",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "files.autoSave": "onFocusChange",
-  "editor.tabSize": 4,
   "editor.wordWrap": "off",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {


### PR DESCRIPTION
## Description

We don't need this, since we have `.editorconfig` setting tabs already.

## Reviewer Focus

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.


