### PR TITLE
docs: :memo: remove reviewer focus section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,11 @@
 ## Description
 
-These changes are for PURPOSE, because REASON.
+This PR DESCRIBE CHANGES.
 
 Closes #
 
-## Reviewer Focus
-
 <!-- Select quick/in-depth as necessary -->
-This PR needs a quick/in-depth review.
-
-Focus on CHANGES.
+This PR needs a quick/an in-depth review.
 
 ## Checklist
 


### PR DESCRIPTION

## Description

This PR removes the reviewer focus section since we tend to write the focus points in the PR description section or comment directly on the specific lines of using the "Reviewer focus" section.

It also simplifies the description a bit, since we also tend to just delete that line and write what we want instead 🤡 

Lastly, it adds an "an" before "in-depth review" 

## Reviewer Focus **Will be gone after this PR** 

<!-- Select quick/in-depth as necessary -->
This PR needs a quick/in-depth review. **I have kept this line**

Focus on CHANGES. **Will be gone after this PR** 
