### PR TITLE
chore: :hammer: add commit linting via pre-commit

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -3,6 +3,8 @@ group:
       # General
       - source: .github/CODEOWNERS
         dest: .github/CODEOWNERS
+      - source: .pre-commit-config.yaml
+        dest: .pre-commit-config.yaml
       - source: .dockerignore
         dest: .dockerignore
       - source: .editorconfig

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+ci:
+    autofix_commit_msg: "chore(pre-commit): :pencil2: automatic fixes"
+    autoupdate_commit_msg: "ci(pre-commit): :construction_worker: update pre-commit CI version"
+
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+
+-   repo: https://github.com/commitizen-tools/commitizen
+    rev: v1.17.0
+    hooks:
+    -   id: commitizen

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,12 +6,12 @@ ci:
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v5.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
 
 -   repo: https://github.com/commitizen-tools/commitizen
-    rev: v1.17.0
+    rev: v3.30.0
     hooks:
     -   id: commitizen

--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ poetry init
 Search for `NAME` and `REPO` and replace them with the name of your project and the repository name. Then look for any `TODO` items.
 
 You will need to set up Fly manually for now.
+
+## Setting things up
+
+Use the commands found in [`spaid`](https://github.com/seedcase-project/spaid) repo to run the next setup steps.

--- a/justfile
+++ b/justfile
@@ -60,7 +60,9 @@ build-website:
   export QUARTO_PYTHON=.venv/bin/python3
   poetry run quarto render --execute
 
-# Add files for a new function (function file and test file)
-add-function app part name:
-  touch ./{{app}}/{{part}}/{{name}}.py
-  touch ./tests/{{part}}/test_{{name}}.py
+check-commit:
+  #!/bin/zsh
+  if [[ $(git rev-parse --abbrev-ref HEAD) != "main" ]]
+  then
+    poetry run cz check --rev-range main..HEAD
+  fi


### PR DESCRIPTION
## Description

This PR adds pre-commit to the repos, which will auto-run commit linting before the commit message is finished.

After this is merged in and sync'ed with Sprout, the spaid command `spaid_setup_dev_workspace` will install everything for this to start working.

Alternatively, this pre-commit will always run on PRs, and will throw an error if a commit message is wrong.

Closes #8, closes seedcase-project/team#89

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.
