### PR TITLE
ci: :construction_worker: needs to push to main, not from PRs

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,9 +1,7 @@
 name: Update version
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
       - main
 


### PR DESCRIPTION
## Description

The release workflow needs to push back to main, so can't use the `on.pull_request` trigger.

<!-- Select quick/in-depth as necessary -->
This PR does not need a review.
