### PR TITLE
fix: add `test-python` to `run-all`

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@
     just --list --unsorted
 
 # Run all build-related recipes in the justfile
-run-all: install-deps format-python check-python run-tests check-commits build-website
+run-all: install-deps format-python check-python test-python check-commits build-website
 
 # Install Python package dependencies
 install-deps:


### PR DESCRIPTION
## Description

The `run-all` recipe wasn't updated when `test-python` was renamed from `run-tests` which resulted in an error when using `run-all`. So it is now 👍

<!-- Select quick/in-depth as necessary -->
This PR needs a quick review.
