### PR TITLE
feat: :sparkles: add examples section to docstring template

### DIFF
--- a/.vscode/google-notypes.mustache
+++ b/.vscode/google-notypes.mustache
@@ -34,3 +34,8 @@ Yields:
     {{descriptionPlaceholder}}.
 {{/yields}}
 {{/yieldsExist}}
+
+Examples:
+    ```{python}
+    {{descriptionPlaceholder}}
+    ```


### PR DESCRIPTION
## Description

Since we generally want to add examples to our Python functions (but maybe not all functions?), I have added it to the docstring template.

Thoughts? Feel free to disagree.

<!-- Select quick/in-depth as necessary -->
This PR needs an in-depth review.