### PR TITLE
build: :bug: `rm` needs `-f` so it doesn't error when there is no file

### DIFF
--- a/justfile
+++ b/justfile
@@ -25,8 +25,9 @@ format-python:
 build-website:
   # To let Quarto know where python is.
   export QUARTO_PYTHON=.venv/bin/python3
-  # Delete any previously built files from quartodoc
-  rm docs/reference/*.qmd
+  # Delete any previously built files from quartodoc.
+  # -f is to not give an error if the files don't exist yet.
+  rm -f docs/reference/*.qmd
   poetry run quartodoc build
   poetry run quarto render --execute
 


### PR DESCRIPTION
## Description

If the qmd files don't exist, `rm` gives an error. So this is to force it to not give an error.

<!-- Select quick/in-depth as necessary -->
Doesn't need a review.
